### PR TITLE
feat: Add /cicd6 endpoint

### DIFF
--- a/src/main/java/com/example/webapp/controller/HealthCheckController.java
+++ b/src/main/java/com/example/webapp/controller/HealthCheckController.java
@@ -59,6 +59,42 @@ public class HealthCheckController {
         }
     }
 
+    @GetMapping("/cicd6")
+    public ResponseEntity<Void> cicdcheck6(@RequestBody(required = false) String body, @RequestParam Map<String, String> params) {
+        logger.info("CICD6 endpoint called");
+
+        if (body != null && !body.isEmpty()) {
+            logger.warn("CICD called with request body, returning 400");
+            return ResponseEntity.badRequest().build(); // 400
+        }
+
+        if (!params.isEmpty()) {
+            logger.warn("Health check called with query parameters: {}, returning 400", params);
+            return ResponseEntity.badRequest().build(); // 400
+        }
+
+        try {
+            logger.debug("Creating cicd test check record");
+            HealthCheck check = new HealthCheck();
+            check.setDatetime(LocalDateTime.now(ZoneOffset.UTC));
+            repository.save(check);
+            logger.info("Health check record created successfully");
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setCacheControl("no-cache, no-store, must-revalidate");
+            headers.setPragma("no-cache");
+
+            logger.info("Health check successful, returning 200 OK");
+            return ResponseEntity.ok().headers(headers).build(); // 200
+        } catch (DataAccessException e) {
+            logger.error("Database access error during health check: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build(); // 503
+        } catch (Exception e) {
+            logger.error("Unexpected error during health check: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build(); // 503
+        }
+    }
+
     @GetMapping("/cicd")
     public ResponseEntity<Void> cicdcheck(@RequestBody(required = false) String body, @RequestParam Map<String, String> params) {
         logger.info("CICD endpoint called");

--- a/src/test/java/com/example/webapp/ControllerTest/HealthCheckControllerTest.java
+++ b/src/test/java/com/example/webapp/ControllerTest/HealthCheckControllerTest.java
@@ -111,4 +111,32 @@ public class HealthCheckControllerTest {
 
     }
 
+    @Test
+    public void testCicd6_Success() {
+        given()
+                .when()
+                .get("/cicd6")
+                .then()
+                .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    public void testCicd6_WithRequestBody() {
+        given()
+                .body("Unexpected body content")
+                .when()
+                .get("/cicd6")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    public void testCicd6_WithQueryParams() {
+        given()
+                .queryParam("test", "test")
+                .when()
+                .get("/cicd6")
+                .then()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
 }


### PR DESCRIPTION
This commit introduces a new GET endpoint `/cicd6` to the `HealthCheckController`.

The new endpoint behaves similarly to the existing `/cicd` endpoints:
- It logs the request.
- It creates a `HealthCheck` record in the database.
- It returns a 200 OK response with appropriate cache-control headers on success.
- It returns a 400 Bad Request if the request includes a body or query parameters.
- It returns a 503 Service Unavailable in case of database errors or other exceptions.

Unit tests have been added to `HealthCheckControllerTest.java` to verify the functionality of the new endpoint, covering success and error cases (request body present, query parameters present).